### PR TITLE
fix a typo in run_benchmarks script

### DIFF
--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -4,7 +4,7 @@ import os
 from tabulate import tabulate
 from tqdm import tqdm
 
-from video_sampler.worker import SamplerConfig, VideoSampler
+from video_sampler.sampler import SamplerConfig, VideoSampler
 
 clip_gate = dict(
     type="clip",


### PR DESCRIPTION
## Summary by Sourcery

cc: @LemurPwned 

Bug Fixes:
- Correct the import path for SamplerConfig and VideoSampler in the run_benchmarks script.