### PR TITLE
Fix TTL counter bug, add tests

### DIFF
--- a/tests/test_ttl_counter.py
+++ b/tests/test_ttl_counter.py
@@ -1,0 +1,23 @@
+from video_sampler.ttl_counter import TTLCounter
+
+
+def test_expire_one_empty():
+    counter = TTLCounter(max_ttl=3)
+    assert counter.expire_one() is None
+
+
+def test_expire_after_tick():
+    counter = TTLCounter(max_ttl=2)
+    counter.add_item("a")
+    counter.tick()
+    assert counter.expire_one() is None
+    counter.tick()
+    assert counter.expire_one() == "a"
+
+
+def test_expire_all():
+    counter = TTLCounter(max_ttl=1)
+    counter.add_item("a")
+    counter.add_item("b")
+    assert list(counter.expire_all()) == ["a", "b"]
+    assert len(counter) == 0

--- a/video_sampler/ttl_counter.py
+++ b/video_sampler/ttl_counter.py
@@ -23,7 +23,8 @@ class TTLCounter:
 
     def expire_one(self):
         """Expire the first item if its TTL is 0. Expires AT MOST one item."""
-        # peek the first item
+        if not self.inner_counter:
+            return None
         ttl, hash = self.inner_counter[0]
         if ttl <= 0:
             heapq.heappop(self.inner_counter)


### PR DESCRIPTION
## Summary
- fix expire_one not handling empty counter
- test TTL counter behavior
- remove unused test import

## Testing
- `pre-commit run --files tests/test_ttl_counter.py video_sampler/ttl_counter.py` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*

## Summary by Sourcery

Fix expire_one not to error on an empty counter and add tests to validate TTL counter behavior

Bug Fixes:
- Handle empty counter in expire_one to return None without error

Tests:
- Add tests covering expire_one on empty and after ticks, and expire_all behavior