### PR TITLE
Fix extractor and gating tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ video_sampler hash "https://www.youtube.com/watch?v=GbpP3Sxp-1U&list=PLFezMcAw96
   --hash-size 3 --buffer-size 20 --ytdlp --keywords "cat,dog,another keyword,test keyword"
 ```
 
+- segment based on audio transcription
+
+```bash
+video_sampler hash some_video.mp4 ./frames/ \
+  --extractor "audio_keyword" --keywords "alert,bell,voice"
+```
+
 The videos are never directly downloaded, only streamed, so you can use it to sample videos from the internet without downloading them first.
 
 ##### Extra YT-DLP options

--- a/tests/test_audio_extractor.py
+++ b/tests/test_audio_extractor.py
@@ -1,0 +1,11 @@
+import sys
+
+import pytest
+
+from video_sampler.language.keyword_capture import AudioKeywordExtractor
+
+
+def test_audio_extractor_requires_whisper(monkeypatch):
+    monkeypatch.setitem(sys.modules, "whisper", None)
+    with pytest.raises(ImportError):
+        AudioKeywordExtractor(["test"])

--- a/video_sampler/gating.py
+++ b/video_sampler/gating.py
@@ -23,6 +23,12 @@ with contextlib.suppress(ImportError):
 
 
 def create_model(model_name: str):
+    if "open_clip" not in globals() or "torch" not in globals():
+        raise ImportError(
+            "open_clip and torch are required for the clip gate. "
+            "Install them to use this feature."
+        )
+
     model, _, preprocess = open_clip.create_model_and_transforms(
         model_name, pretrained="laion2b_s34b_b79k"
     )

--- a/video_sampler/gating.py
+++ b/video_sampler/gating.py
@@ -23,11 +23,14 @@ with contextlib.suppress(ImportError):
 
 
 def create_model(model_name: str):
-    if "open_clip" not in globals() or "torch" not in globals():
+    try:
+        import open_clip
+        import torch
+    except ImportError as e:
         raise ImportError(
             "open_clip and torch are required for the clip gate. "
             "Install them to use this feature."
-        )
+        ) from e
 
     model, _, preprocess = open_clip.create_model_and_transforms(
         model_name, pretrained="laion2b_s34b_b79k"

--- a/video_sampler/language/__init__.py
+++ b/video_sampler/language/__init__.py
@@ -1,0 +1,3 @@
+from .keyword_capture import AudioKeywordExtractor, KeywordExtractor
+
+__all__ = ["KeywordExtractor", "AudioKeywordExtractor"]


### PR DESCRIPTION
## Summary
- restore `generate_segments` in KeywordExtractor
- ensure ClipGate dependencies raise `ImportError`
- fix test using `monkeypatch.setitem`

## Testing
- `black tests/test_audio_extractor.py video_sampler/language/keyword_capture.py video_sampler/gating.py`
- `isort tests/test_audio_extractor.py video_sampler/language/keyword_capture.py video_sampler/gating.py`

## Summary by Sourcery

Introduce audio-powered keyword extraction using Whisper, enforce dependency checks for the Clip gate, and update documentation and tests accordingly.

New Features:
- Add AudioKeywordExtractor for audio-based keyword extraction via Whisper
- Extend create_extractor to support the new audio_keyword extractor type

Bug Fixes:
- Ensure gating create_model raises ImportError when open_clip or torch are missing

Enhancements:
- Simplify KeywordExtractor.generate_segments docstring
- Re-export KeywordExtractor and AudioKeywordExtractor in language package init

Documentation:
- Document audio-based keyword extraction usage in README

Tests:
- Add test to verify ImportError when Whisper is unavailable for AudioKeywordExtractor